### PR TITLE
fix: respect system theme and add dark/light toggle in extension popup

### DIFF
--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -11,22 +11,47 @@
         box-sizing: border-box;
       }
 
+      :root{
+        --bg-color: #ffffff;
+        --text-color: #000000;
+      }
+
+      [data-theme="dark"]{
+        --bg-color: #0a0a0a;
+        --text-color: #ffffff;
+      }
+
       body {
         width: 400px;
         min-height: 500px;
         font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto",
           "Oxygen", "Ubuntu", "Cantarell", sans-serif;
-        background: #0a0a0a;
-        color: #ffffff;
+        background-color: var(--bg-color);
+        color: var(--text-color);
+        transition: background-color 0.3s, color 0.3s;
       }
 
       #root {
         width: 100%;
         height: 100%;
       }
+
+      .theme-toggle{
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        background: none;
+        border: 1px solid var(--text-color);
+        color: var(--text-color);
+        padding: 4px 8px;
+        border-radius: 6px;
+        cursor: pointer;
+        font-size: 12px;
+      }
     </style>
   </head>
   <body>
+    <button id="themeToggle" class="theme-toggle">Toggle Theme</button>
     <div id="root"></div>
     <script type="module" src="./popup.js"></script>
     <link rel="stylesheet" href="./assets/popup.css" />

--- a/client/src/ExtensionApp.jsx
+++ b/client/src/ExtensionApp.jsx
@@ -30,7 +30,32 @@ function ExtensionApp() {
   const [stats, setStats] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const [theme, setTheme] = useState("light");
 
+  // ---------------- THEME HANDLING ----------------
+  useEffect(() => {
+    // Load theme from storage or system preference
+    chrome.storage.local.get(["theme"], (result) => {
+      if (result.theme) {
+        setTheme(result.theme);
+        document.documentElement.classList.toggle("dark", result.theme === "dark");
+      } else {
+        const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+        const initialTheme = prefersDark ? "dark" : "light";
+        setTheme(initialTheme);
+        document.documentElement.classList.toggle("dark", prefersDark);
+      }
+    });
+  }, []);
+
+  const toggleTheme = () => {
+    const newTheme = theme === "light" ? "dark" : "light";
+    setTheme(newTheme);
+    document.documentElement.classList.toggle("dark", newTheme === "dark");
+    chrome.storage.local.set({ theme: newTheme });
+  };
+
+  // ---------------- EXISTING LOGIC ----------------
   useEffect(() => {
     // Get username or repo from current GitHub page if applicable
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
@@ -192,6 +217,10 @@ function ExtensionApp() {
             <h1 className="text-xl font-bold text-white">en-git</h1>
           </div>
           <div className="flex items-center gap-2">
+            {/* Theme Toggle Button*/}
+            <Button onClick={toggleTheme} size="sm" variant="secondary" className="gap-1">
+              {theme === "light" ? "Dark" : "Light"}
+            </Button>
             <Button onClick={openSettings} size="sm" variant="secondary" className="gap-1">
               <SettingsIcon className="h-3 w-3" />
               Settings

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -250,3 +250,19 @@
   --shadow-xl: var(--shadow-xl);
   --shadow-2xl: var(--shadow-2xl);
 }
+
+:root {
+  --bg-color: #ffffff;
+  --text-color: #000000;
+}
+
+.dark {
+  --bg-color: #0a0a0a;
+  --text-color: #ffffff;
+}
+
+body {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  transition: background-color 0.3s ease, color 0.3s ease;
+}


### PR DESCRIPTION
# 🔀 Pull Request

## 📝 Summary
This PR updates the extension popup to respect the user’s system theme (light/dark) on load and adds a toggle button in the header to switch between dark and light mode manually.

## 🔗 Related Issues
-Fixes: #1 

## 🔧 Type of Change
Select the type of change this PR introduces:
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code refactor
- [ ] 🧾 Documentation update
- [ ] ⚙️ Build/config change
- [ ] ♻️ Other (specify below)

## 🔄 Changes Made
List the key modifications introduced by this PR:
-Detects system theme on popup load and applies corresponding light/dark mode.
-Adds a toggle button in the popup header to manually switch themes.
-Saves user preference in Chrome storage so the theme persists across sessions.
-Minor CSS adjustments to ensure proper background/text colors in both modes. 

## 🧪 How to Test
Steps to verify this PR locally:
1. Load the extension in Chrome via chrome://extensions → Load unpacked → select the dist or chrome-extension folder.
2. Open the extension popup: it should match your system’s light/dark theme.
3. Click the 🌙 / ☀️ toggle button to switch themes and reload the popup - it should remember your choice.

Commands (if any):
```bash
npm install
npm run dev
```

## 📸 Screenshots
| Before | After |
| ------ | ----- |
|        |       |

## ✅ Checklist
- [x] I have tested my changes locally.
- [x] My code follows the project's coding style.
- [ ] I have updated the documentation if necessary.
- [ ] I have added tests to cover my changes.